### PR TITLE
Remchain to ERC20 Rem swap function

### DIFF
--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -207,11 +207,14 @@ contract MultiSigWallet {
     {
         bytes32 swapId = sha256("eth", "*", destination, "*", value, "*", nonce, "*", data);
         transactionId = 0;
-        for (uint i=0; i<transactionCount; i++)
+        for (uint i=transactionCount; i>=0; i--) {
+            if (transactions[i].executed)
+                break;
             if (transactions[i].swapId == swapId) {
                 transactionId = i;
                 break;
             }
+        }
         if (transactionId == 0 || transactionCount == 0) {
             transactionId = addTransaction(destination, value, data);
             transactions[transactionId].swapId = swapId;


### PR DESCRIPTION
Allows an owner to submit and confirm a swap transaction from Remchain to ERC20 REM.
Parameters:
 - destination - Transaction target address.
 - value - Transaction ether value.
 - nonce - Transaction counter in Remchain.
 - data - Transaction data payload.

Returns transaction ID.